### PR TITLE
Add support for includedRegions and excludedRegions in jenkins jobDSL

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/ghprb/jobdsl/GhprbTriggerContext.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/jobdsl/GhprbTriggerContext.java
@@ -270,15 +270,18 @@ class GhprbTriggerContext implements Context {
         this.excludedRegions = regions;
     }
     public void includedRegions(Iterable<String> regions){
+	String includedRegionsStr = "";
 	for (String region: regions) {
-             this.includedRegions += (region + "\n");    
+             includedRegionsStr += (region + "\n");    
         }
-
+	includedRegions(includedRegionsStr);
     }
     public void excludedRegions(Iterable<String> regions){
-        for (String region: regions) {
-             this.excludedRegions += (region+ "\n");
+        String excludedRegionsStr = "";
+	for (String region: regions) {
+             excludedRegionsStr += (region+ "\n");
         }
+        excludedRegions(excludedRegionsStr);
 
     }
 

--- a/src/main/java/org/jenkinsci/plugins/ghprb/jobdsl/GhprbTriggerContext.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/jobdsl/GhprbTriggerContext.java
@@ -271,13 +271,13 @@ class GhprbTriggerContext implements Context {
     }
     public void includedRegions(Iterable<String> regions){
 	for (String region: regions) {
-             this.includedRegions += region;    
+             this.includedRegions += (region + "\n");    
         }
 
     }
     public void excludedRegions(Iterable<String> regions){
         for (String region: regions) {
-             this.excludedRegions += region;
+             this.excludedRegions += (region+ "\n");
         }
 
     }

--- a/src/main/java/org/jenkinsci/plugins/ghprb/jobdsl/GhprbTriggerContext.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/jobdsl/GhprbTriggerContext.java
@@ -269,4 +269,17 @@ class GhprbTriggerContext implements Context {
     public void excludedRegions(String regions){
         this.excludedRegions = regions;
     }
+    public void includedRegions(Iterable<String> regions){
+	for (String region: regions) {
+             this.includedRegions += region;    
+        }
+
+    }
+    public void excludedRegions(Iterable<String> regions){
+        for (String region: regions) {
+             this.excludedRegions += region;
+        }
+
+    }
+
 }

--- a/src/main/java/org/jenkinsci/plugins/ghprb/jobdsl/GhprbTriggerContext.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/jobdsl/GhprbTriggerContext.java
@@ -263,10 +263,10 @@ class GhprbTriggerContext implements Context {
     }
  
     public void includedRegions(String regions){
-    	this.includedRegions = regions
+    	this.includedRegions = regions;
     }
 
     public void excludedRegions(String regions){
-        this.excludedRegions = regions
+        this.excludedRegions = regions;
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/ghprb/jobdsl/GhprbTriggerContext.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/jobdsl/GhprbTriggerContext.java
@@ -261,4 +261,12 @@ class GhprbTriggerContext implements Context {
     public void extensions(Runnable closure) {
         ContextExtensionPoint.executeInContext(closure, extensionContext);
     }
+ 
+    public void includedRegions(String regions){
+    	this.includedRegions = regions
+    }
+
+    public void excludedRegions(String regions){
+        this.excludedRegions = regions
+    }
 }


### PR DESCRIPTION
Adding fix to the GhprbTriggerContext.Java to support the includedRegions and excludedRegions with JobDSL.